### PR TITLE
Justin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+ES_ENDPOINT = '<your-endpoint-here>'
+ES_API_KEY = '<your-api-key-here>'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 uv.lock
 .python-version
 *.pyc
+pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+.env
+uv.lock
+.python-version
+*.pyc

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ source .venv/bin/activate
 
 Install the necessary Python packages. Note that we are specifying a compatible version for the `elasticsearch` library to match the v8.x server used in this tutorial.
 ```shell
-uv add "mcp[cli]" "elasticsearch>=8.0.0,<9.0.0" aiohttp pydantic
+uv add "mcp[cli]" "elasticsearch>=8.0.0,<9.0.0" aiohttp pydantic dotenv-python
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,19 @@ uv add "mcp[cli]" "elasticsearch>=8.0.0,<9.0.0" aiohttp pydantic
 
 ## Environment Configuration
 
-### Setting up the API Key
+### Creating the `.env` file
+This demo uses the `dotenv` environment variable library which sets local environment variables instead of requiring global scope. 
 
-After creating the API key in Elasticsearch, you need to configure it in your environment:
-
+1. Duplicate the `.env.example` file and rename the new file to `.env`. 
 ```bash
-# Export the API key for the current session
-export ES_API_KEY="your_encoded_api_key_here"
+cp .env.example .env
 ```
+
+2. Set the `ES_ENDPOINT` url if you are using a cloud instance of Elasticsearch. If you are using a local instance of Elasticsearch, leave it blank.
+3. Set the `ES_API_KEY` string. Instructions on creating an API key may be found [here](https://www.elastic.co/docs/deploy-manage/api-keys/elasticsearch-api-keys#create-api-key).
+4. Save the file.
+
+When the demo files are ran, the `dotenv` library will automatically pull these environment variables into the code.
 
 ## Usage Instructions
 
@@ -137,6 +142,7 @@ You should see a structure similar to this inside the file, under the "mcpServer
 ## File Descriptions
 
 * `apple_watch_mcp.py`: The **complete and final script** for the MCP server, containing all implemented Resources, Tools, and Prompts.
+* `utilities.py`: Helper methods used in the `apple_watch_mcp.py` tool functions for clarity and conciseness.
 * `ingest_data.py`: A helper script that populates your Elasticsearch instance with the sample data.
 * `sample_data.json`: A JSON file containing fictitious Apple Health step count data for testing.
 * `README.md`: This file, providing instructions to run the complete solution.

--- a/apple_watch_mcp.py
+++ b/apple_watch_mcp.py
@@ -10,7 +10,7 @@ import json
 from dotenv import load_dotenv
 
 from datetime import datetime
-from pydantic import BaseModel, field_validator, ValidationError
+from pydantic import BaseModel, field_validator
 from typing import Any, Optional
 
 from elasticsearch import AsyncElasticsearch

--- a/apple_watch_mcp.py
+++ b/apple_watch_mcp.py
@@ -16,6 +16,12 @@ from typing import Any, Optional
 from elasticsearch import AsyncElasticsearch
 from contextlib import asynccontextmanager
 
+from utilities import (
+    build_elasticsearch_query,
+    process_aggregated_results,
+    process_raw_results,
+)
+
 from mcp.server.fastmcp import FastMCP
 
 # Load environment variables from .env file
@@ -36,8 +42,8 @@ class QueryStepDataParams(BaseModel):
     end_date: Optional[str] = None
     aggregation: Optional[str] = None
     device: Optional[str] = None
-    
-    @field_validator('start_date', 'end_date')
+
+    @field_validator("start_date", "end_date")
     def validate_date_format(cls, value):
         if value is None:
             return value
@@ -46,13 +52,16 @@ class QueryStepDataParams(BaseModel):
             return value
         except ValueError:
             raise ValueError("Invalid date format. Use YYYY-MM-DD")
-    
-    @field_validator('aggregation')
+
+    @field_validator("aggregation")
     def validate_aggregation(cls, value):
         valid_aggregations = ["hourly", "daily", "weekly", "monthly", None]
         if value not in valid_aggregations:
-            raise ValueError(f"Invalid aggregation. Use one of: {valid_aggregations[:-1]}")
+            raise ValueError(
+                f"Invalid aggregation. Use one of: {valid_aggregations[:-1]}"
+            )
         return value
+
 
 @asynccontextmanager
 async def get_es_client():
@@ -63,18 +72,16 @@ async def get_es_client():
     finally:
         await client.close()
 
+
 # Elasticsearch helper function
 async def query_elasticsearch(query: dict) -> dict[str, Any] | None:
     """Makes a request to Elasticsearch with proper error handling."""
     print(f"Sending query to Elasticsearch: {json.dumps(query)}")
-    
+
     # Use context manager
     async with get_es_client() as client:
         try:
-            response = await client.search(
-                index=ES_INDEX,
-                body=query
-            )
+            response = await client.search(index=ES_INDEX, body=query)
             return response
         except Exception as e:
             print(f"Error querying Elasticsearch: {e}")
@@ -87,80 +94,64 @@ async def list_step_types() -> str:
     """List all available step types in the database"""
     query = {
         "size": 0,
-        "aggs": {
-            "step_types": {
-                "terms": {
-                    "field": "type",
-                    "size": 100
-                }
-            }
-        }
+        "aggs": {"step_types": {"terms": {"field": "type", "size": 100}}},
     }
-    
+
     data = await query_elasticsearch(query)
     if not data:
         return json.dumps({"error": "Unable to query Elasticsearch"}, indent=2)
-    
-    step_types = [bucket["key"] for bucket in data["aggregations"]["step_types"]["buckets"]]
-    
-    return json.dumps({
-        "available_types": step_types,
-        "count": len(step_types)
-    }, indent=2)
+
+    step_types = [
+        bucket["key"] for bucket in data["aggregations"]["step_types"]["buckets"]
+    ]
+
+    return json.dumps(
+        {"available_types": step_types, "count": len(step_types)}, indent=2
+    )
+
 
 @mcp.resource("health://steps/latest")
 async def get_latest_steps() -> str:
     """Gets the most recent step records"""
     query = {
-        "query": {
-            "match_all": {}
-        },
-        "sort": [
-            {"endDate": {"order": "desc"}}
-        ],
-        "size": 10
+        "query": {"match_all": {}},
+        "sort": [{"endDate": {"order": "desc"}}],
+        "size": 10,
     }
-    
+
     data = await query_elasticsearch(query)
     if not data:
         return json.dumps({"error": "Unable to query Elasticsearch"}, indent=2)
-    
+
     results = []
     for hit in data["hits"]["hits"]:
         source = hit["_source"]
-        results.append({
-            "startDate": source.get("startDate"),
-            "endDate": source.get("endDate"),
-            "value": source.get("value"),
-            "device": source.get("device"),
-            "sourceName": source.get("sourceName"),
-            "dayOfWeek": source.get("dayOfWeek"),
-            "hour": source.get("hour")
-        })
-    
-    return json.dumps({
-        "latest_steps": results
-    }, indent=2)
+        results.append(
+            {
+                "startDate": source.get("startDate"),
+                "endDate": source.get("endDate"),
+                "value": source.get("value"),
+                "device": source.get("device"),
+                "sourceName": source.get("sourceName"),
+                "dayOfWeek": source.get("dayOfWeek"),
+                "hour": source.get("hour"),
+            }
+        )
+
+    return json.dumps({"latest_steps": results}, indent=2)
+
 
 @mcp.resource("health://steps/summary")
 async def get_steps_summary() -> str:
     """Get summary statistics for step counts"""
-    query = {
-        "aggs": {
-            "all_time": {
-                "stats": {
-                    "field": "value"
-                }
-            }
-        },
-        "size": 0
-    }
-    
+    query = {"aggs": {"all_time": {"stats": {"field": "value"}}}, "size": 0}
+
     data = await query_elasticsearch(query)
     if not data:
         return json.dumps({"error": "Unable to query Elasticsearch"}, indent=2)
-    
+
     return json.dumps(data["aggregations"], indent=2)
+
 
 # Tools
 @mcp.tool()
@@ -181,16 +172,14 @@ async def query_step_data(params: QueryStepDataParams) -> str:
     aggregation = params.aggregation or ""
     device = params.device or ""
 
-
     # Build and execute query
     query = build_elasticsearch_query(start_date, end_date, device, aggregation)
-   
+
     data = await query_elasticsearch(query)
     if not data:
         return json.dumps(
             {"error": "Unable to query Elasticsearch", "query": query}, indent=2
         )
-
 
     # Process results based on aggregation type
     if aggregation:
@@ -198,42 +187,41 @@ async def query_step_data(params: QueryStepDataParams) -> str:
     else:
         results = process_raw_results(data)
 
+    return json.dumps(
+        {
+            "aggregation": aggregation,
+            "total_records": data["hits"]["total"]["value"],
+            "data": results,
+            "query": query,
+        },
+        indent=2,
+    )
 
-    return json.dumps({
-        "aggregation": aggregation,
-        "total_records": data["hits"]["total"]["value"],
-        "data": results,
-        "query": query,
-    }, indent=2)
 
 @mcp.tool()
 async def get_all_steps() -> str:
     """Get all steps without any filtering"""
-    query = {
-        "query": {
-            "match_all": {}
-        },
-        "size": 10,
-        "sort": [{"startDate": "desc"}]
-    }
-    
+    query = {"query": {"match_all": {}}, "size": 10, "sort": [{"startDate": "desc"}]}
+
     data = await query_elasticsearch(query)
     if not data:
         return json.dumps({"error": "Unable to query Elasticsearch"}, indent=2)
-    
+
     results = []
     for hit in data["hits"]["hits"]:
         source = hit["_source"]
-        results.append({
-            "startDate": source.get("startDate"),
-            "value": source.get("value"),
-            "device": source.get("device")
-        })
-    
-    return json.dumps({
-        "total_records": data["hits"]["total"]["value"],
-        "data": results
-    })
+        results.append(
+            {
+                "startDate": source.get("startDate"),
+                "value": source.get("value"),
+                "device": source.get("device"),
+            }
+        )
+
+    return json.dumps(
+        {"total_records": data["hits"]["total"]["value"], "data": results}
+    )
+
 
 # Prompts
 @mcp.prompt()
@@ -254,6 +242,7 @@ def daily_report(date: str = None) -> str:
 4. Comparison with weekly average
 5. Graphical visualization of the data, if possible"""
 
+
 @mcp.prompt()
 def trend_analysis(start_date: str, end_date: str) -> str:
     """Analyze step trends over a specific period"""
@@ -265,6 +254,7 @@ Please include:
 4. Progression over time
 5. Recommendations based on the data"""
 
+
 @mcp.prompt()
 def device_comparison() -> str:
     """Compare step data recorded by different devices"""
@@ -274,6 +264,7 @@ def device_comparison() -> str:
 3. Times when each device is used more
 4. Apparent accuracy of each device
 5. Recommendations on which device to prioritize for tracking"""
+
 
 # Main function to run the server
 if __name__ == "__main__":

--- a/apple_watch_mcp.py
+++ b/apple_watch_mcp.py
@@ -224,23 +224,20 @@ async def get_all_steps() -> str:
 
 
 # Prompts
-@mcp.prompt()
+@mcp.prompt("/daily_report")
 def daily_report(date: str = None) -> str:
     """Create a daily step report for a specific date"""
-    if date:
-        return f"""Please analyze the step data for {date}. Provide:
-1. Total steps
-2. Average steps per active hour
-3. Most active periods of the day
-4. Comparison with weekly average
-5. Graphical visualization of the data, if possible"""
-    else:
-        return """Please analyze the step data for today. Provide:
-1. Total steps so far
-2. Average steps per active hour
-3. Most active periods of the day
-4. Comparison with weekly average
-5. Graphical visualization of the data, if possible"""
+    date_display = date or "today"
+    steps_qualifier = "so far" if not date else ""
+
+    return f"""Please analyze the step data for {date_display}. 
+                Provide:
+                1. Total steps{' ' + steps_qualifier if steps_qualifier else ''}
+                2. Average steps per active hour
+                3. Most active periods of the day
+                4. Comparison with weekly average
+                5. Graphical visualization of the 
+                data, if possible"""
 
 
 @mcp.prompt()

--- a/apple_watch_mcp.py
+++ b/apple_watch_mcp.py
@@ -6,23 +6,28 @@ A Model Context Protocol server for querying Apple HealthKit step data stored in
 Author: Alex Salgado
 """
 import os
-from typing import Any, Optional
 import json
+from dotenv import load_dotenv
+
 from datetime import datetime
 from pydantic import BaseModel, field_validator, ValidationError
-from mcp.server.fastmcp import FastMCP
+from typing import Any, Optional
+
 from elasticsearch import AsyncElasticsearch
 from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+
+# Load environment variables from .env file
+load_dotenv()
 
 # Initialize FastMCP server
 mcp = FastMCP("apple-watch-steps")
 
 # Constants
-ES_HOST = "http://localhost:9200"
+ES_ENDPOINT = os.environ.get("ES_ENDPOINT", "http://localhost:9200")
+ES_API_KEY = os.environ.get("ES_API_KEY")
 ES_INDEX = "apple-health-steps"
-
-# API key from environment variable or fallback for development
-ES_API_KEY = os.getenv('ES_API_KEY')
 
 
 # Pydantic model for parameter validation
@@ -52,7 +57,7 @@ class QueryStepDataParams(BaseModel):
 @asynccontextmanager
 async def get_es_client():
     """Context manager for Elasticsearch client."""
-    client = AsyncElasticsearch([ES_HOST], api_key=ES_API_KEY)
+    client = AsyncElasticsearch([ES_ENDPOINT], api_key=ES_API_KEY)
     try:
         yield client
     finally:
@@ -162,118 +167,43 @@ async def get_steps_summary() -> str:
 async def query_step_data(params: QueryStepDataParams) -> str:
     """
     Query step data with customizable parameters
-    
+
+
     Args:
         start_date: Start date in YYYY-MM-DD format
         end_date: End date in YYYY-MM-DD format
         aggregation: Aggregation interval (hourly, daily, weekly, monthly)
         device: Filter by specific device name
     """
-    # Extract parameters from model
+    # Extract parameters
     start_date = params.start_date or ""
     end_date = params.end_date or ""
     aggregation = params.aggregation or ""
     device = params.device or ""
-    
-    query = {"query": {"match_all": {}}}
-    filters = []
-    
-    # Date filters
-    date_ranges = []
-    if start_date:
-        date_ranges.append({"gte": start_date})
-    if end_date:
-        date_ranges.append({"lte": end_date})
-    
-    if date_ranges:
-        filters.append({
-            "range": {
-                "day": {**{k: v for d in date_ranges for k, v in d.items()}}
-            }
-        })
-    
-    # Device filter
-    if device:
-        filters.append({
-            "wildcard": {
-                "device": f"*{device}*"
-            }
-        })
-    
-    if filters:
-        query["query"] = {"bool": {"must": filters}}
-    
-    # Aggregation handling
-    if aggregation:
-        interval_mapping = {
-            "hourly": "1h",
-            "daily": "1d", 
-            "weekly": "1w",
-            "monthly": "1M"
-        }
-        interval = interval_mapping.get(aggregation, "1d")
-        date_field = "startDate" if aggregation == "hourly" else "day"
-        
-        query["aggs"] = {
-            "time_series": {
-                "date_histogram": {
-                    "field": date_field,
-                    "calendar_interval": interval,
-                    "min_doc_count": 0
-                },
-                "aggs": {
-                    "total_steps": {"sum": {"field": "value"}},
-                    "avg_steps": {"avg": {"field": "value"}},
-                    "max_steps": {"max": {"field": "value"}},
-                    "min_steps": {"min": {"field": "value"}}
-                }
-            }
-        }
-        query["size"] = 0
-    else:
-        query.update({
-            "sort": [{"startDate": "desc"}],
-            "size": 10
-        })
-    
+
+
+    # Build and execute query
+    query = build_elasticsearch_query(start_date, end_date, device, aggregation)
+   
     data = await query_elasticsearch(query)
     if not data:
-        return json.dumps({
-            "error": "Unable to query Elasticsearch",
-            "query": query
-        }, indent=2)
-    
-    # Process results
-    results = []
-    if aggregation and "time_series" in data.get("aggregations", {}):
-        for bucket in data["aggregations"]["time_series"]["buckets"]:
-            results.append({
-                "date": bucket["key_as_string"],
-                "total_steps": bucket["total_steps"]["value"],
-                "average_steps": bucket["avg_steps"]["value"],
-                "max_steps": bucket["max_steps"]["value"],
-                "min_steps": bucket["min_steps"]["value"],
-                "records": bucket["doc_count"]
-            })
+        return json.dumps(
+            {"error": "Unable to query Elasticsearch", "query": query}, indent=2
+        )
+
+
+    # Process results based on aggregation type
+    if aggregation:
+        results = process_aggregated_results(data)
     else:
-        for hit in data["hits"]["hits"]:
-            source = hit["_source"]
-            results.append({
-                "startDate": source.get("startDate"),
-                "endDate": source.get("endDate"),
-                "day": source.get("day"),
-                "dayOfWeek": source.get("dayOfWeek"),
-                "hour": source.get("hour"),
-                "value": source.get("value"),
-                "device": source.get("device"),
-                "sourceName": source.get("sourceName")
-            })
-    
+        results = process_raw_results(data)
+
+
     return json.dumps({
         "aggregation": aggregation,
         "total_records": data["hits"]["total"]["value"],
         "data": results,
-        "query": query
+        "query": query,
     }, indent=2)
 
 @mcp.tool()

--- a/ingest_data.py
+++ b/ingest_data.py
@@ -5,14 +5,19 @@ import json
 from elasticsearch import Elasticsearch, helpers
 import os
 
+from dotenv import load_dotenv
 
-# --- Configuration ---
-ES_HOST = "http://localhost:9200"
+# Load environment variables from .env file
+load_dotenv()
+
+# Constants
+ES_ENDPOINT = os.environ.get("ES_ENDPOINT", "http://localhost:9200")
+ES_API_KEY = os.environ.get("ES_API_KEY")
 ES_INDEX = "apple-health-steps"
 DATA_FILE_PATH = "sample_data.json"
 
 # API key from environment variable or fallback for development
-ES_API_KEY = os.getenv('ES_API_KEY')
+ES_API_KEY = os.getenv("ES_API_KEY")
 
 
 # --- Index Mapping ---
@@ -28,48 +33,37 @@ INDEX_MAPPING = {
                     "manufacturer": {"type": "keyword"},
                     "model": {"type": "keyword"},
                     "hardware": {"type": "keyword"},
-                    "software": {"type": "keyword"}
+                    "software": {"type": "keyword"},
                 }
             },
             "unit": {"type": "keyword"},
             "creationDate": {
                 "type": "date",
-                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
             },
             "startDate": {
                 "type": "date",
-                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
             },
             "endDate": {
                 "type": "date",
-                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis",
             },
             "value": {"type": "float"},
-            "day": {
-                "type": "date",
-                "format": "yyyy-MM-dd"
-            },
+            "day": {"type": "date", "format": "yyyy-MM-dd"},
             "dayOfWeek": {"type": "keyword"},
             "hour": {"type": "integer"},
-            "duration": {"type": "float"}
+            "duration": {"type": "float"},
         }
     },
-    "settings": {
-        "number_of_shards": 1,  # WARNING: For production, consider using more shards based on your data volume
-        "number_of_replicas": 0  # WARNING: This is set to 0 for development. For production, use at least 1 replica for fault tolerance
-        
-    }
 }
 
 
 def create_es_client():
     """Creates and returns an Elasticsearch client."""
-    print(f"Connecting to Elasticsearch at {ES_HOST}...")
+    print(f"Connecting to Elasticsearch at {ES_ENDPOINT}...")
     try:
-        client = Elasticsearch(
-            hosts=[ES_HOST],
-            api_key=ES_API_KEY
-        )
+        client = Elasticsearch(hosts=[ES_ENDPOINT], api_key=ES_API_KEY)
         if not client.ping():
             raise ConnectionError("Could not connect to Elasticsearch.")
         print("Connection successful!")
@@ -78,17 +72,16 @@ def create_es_client():
         print(f"Connection error: {e}")
         return None
 
+
 def generate_actions(filepath, index_name):
     """
     Reads a JSON array from a file and yields a generator of actions for the bulk API.
     """
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         data = json.load(f)  # Load the entire JSON array
     for doc in data:
-        yield {
-            "_index": index_name,
-            "_source": doc
-        }
+        yield {"_index": index_name, "_source": doc}
+
 
 def ingest_data(client: Elasticsearch):
     """
@@ -110,7 +103,7 @@ def ingest_data(client: Elasticsearch):
     try:
         # Use the generator to prepare actions for the bulk helper
         actions = generate_actions(DATA_FILE_PATH, ES_INDEX)
-        
+
         # Ingest the data using the bulk helper
         success, failed = helpers.bulk(client, actions)
         print(f"Ingestion complete. Documents successfully ingested: {success}")
@@ -123,10 +116,10 @@ def ingest_data(client: Elasticsearch):
     except Exception as e:
         print(f"An error occurred during file reading or ingestion: {e}")
         return
-    
+
     # 4. Refresh and print the final document count.
     client.indices.refresh(index=ES_INDEX)
-    count = client.count(index=ES_INDEX)['count']
+    count = client.count(index=ES_INDEX)["count"]
     print(f"Final check: The index '{ES_INDEX}' now contains {count} documents.")
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -1,0 +1,131 @@
+"""
+Utility functions for Apple Watch Health Data MCP Server
+"""
+from typing import Any, Dict, List
+
+
+def build_elasticsearch_query(start_date: str, end_date: str, device: str, aggregation: str) -> Dict[str, Any]:
+    """
+    Build Elasticsearch query based on provided parameters.
+    
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format
+        device: Device name to filter by
+        aggregation: Aggregation interval (hourly, daily, weekly, monthly)
+    
+    Returns:
+        Dictionary containing the Elasticsearch query
+    """
+    query = {"query": {"match_all": {}}}
+    filters = []
+    
+    # Date filters
+    date_ranges = []
+    if start_date:
+        date_ranges.append({"gte": start_date})
+    if end_date:
+        date_ranges.append({"lte": end_date})
+    
+    if date_ranges:
+        filters.append({
+            "range": {
+                "day": {**{k: v for d in date_ranges for k, v in d.items()}}
+            }
+        })
+    
+    # Device filter
+    if device:
+        filters.append({
+            "wildcard": {
+                "device": f"*{device}*"
+            }
+        })
+    
+    if filters:
+        query["query"] = {"bool": {"must": filters}}
+    
+    # Aggregation handling
+    if aggregation:
+        interval_mapping = {
+            "hourly": "1h",
+            "daily": "1d", 
+            "weekly": "1w",
+            "monthly": "1M"
+        }
+        interval = interval_mapping.get(aggregation, "1d")
+        date_field = "startDate" if aggregation == "hourly" else "day"
+        
+        query["aggs"] = {
+            "time_series": {
+                "date_histogram": {
+                    "field": date_field,
+                    "calendar_interval": interval,
+                    "min_doc_count": 0
+                },
+                "aggs": {
+                    "total_steps": {"sum": {"field": "value"}},
+                    "avg_steps": {"avg": {"field": "value"}},
+                    "max_steps": {"max": {"field": "value"}},
+                    "min_steps": {"min": {"field": "value"}}
+                }
+            }
+        }
+        query["size"] = 0
+    else:
+        query.update({
+            "sort": [{"startDate": "desc"}],
+            "size": 10
+        })
+    
+    return query
+
+
+def process_aggregated_results(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Process aggregated Elasticsearch results.
+    
+    Args:
+        data: Raw Elasticsearch response data
+    
+    Returns:
+        List of processed aggregated results
+    """
+    results = []
+    if "aggregations" in data and "time_series" in data["aggregations"]:
+        for bucket in data["aggregations"]["time_series"]["buckets"]:
+            results.append({
+                "date": bucket["key_as_string"],
+                "total_steps": bucket["total_steps"]["value"],
+                "average_steps": bucket["avg_steps"]["value"],
+                "max_steps": bucket["max_steps"]["value"],
+                "min_steps": bucket["min_steps"]["value"],
+                "records": bucket["doc_count"]
+            })
+    return results
+
+
+def process_raw_results(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Process raw Elasticsearch results.
+    
+    Args:
+        data: Raw Elasticsearch response data
+    
+    Returns:
+        List of processed raw results
+    """
+    results = []
+    for hit in data["hits"]["hits"]:
+        source = hit["_source"]
+        results.append({
+            "startDate": source.get("startDate"),
+            "endDate": source.get("endDate"),
+            "day": source.get("day"),
+            "dayOfWeek": source.get("dayOfWeek"),
+            "hour": source.get("hour"),
+            "value": source.get("value"),
+            "device": source.get("device"),
+            "sourceName": source.get("sourceName")
+        })
+    return results


### PR DESCRIPTION
Made a couple small initialization and administrative changes, no actual change to the demo code:
- added `dotenv` to handle env vars easier
- created `.env.example` and instructions on how to set up
- set env vars in code to pull `dotenv` vars or default to `localhost:9200`
- moved some code from mcp tool to a utilities function for an overall smaller mcp tool function code line footprint.
- updated README.md to support `dotenv` library